### PR TITLE
🏷️ Release 1.0.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://registry.npmjs.org
       - name: Install Packages
         run: yarn install

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/optro-cloud/optro-api-client.git"
   },
   "website": "https://www.optro.cloud",
-  "version": "1.0.5",
-  "license": "Commercial",
+  "version": "1.0.6",
+  "license": "MIT",
   "scripts": {
     "build": "tsc"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "typescript": "^4.1.3"
   },
   "optionalDependencies": {
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.7"
   }
 }


### PR DESCRIPTION
- Update `node-fetch` to 2.6.7 to patch a security vulnerability
- Update the GH action to use node 16
- Change license to a valid SPDX license expression